### PR TITLE
Allow the use of CCBUUID

### DIFF
--- a/Source/BKConfiguration.swift
+++ b/Source/BKConfiguration.swift
@@ -57,6 +57,13 @@ public class BKConfiguration {
         endOfDataMark = "EOD".dataUsingEncoding(NSUTF8StringEncoding)!
         dataCancelledMark = "COD".dataUsingEncoding(NSUTF8StringEncoding)!
     }
+    
+    public init(dataServiceCBUUID: CBUUID, dataServiceCharacteristicUUID: NSUUID) {
+        self.dataServiceUUID = dataServiceCBUUID
+        self.dataServiceCharacteristicUUID = CBUUID(NSUUID: dataServiceCharacteristicUUID)
+        endOfDataMark = "EOD".dataUsingEncoding(NSUTF8StringEncoding)!
+        dataCancelledMark = "COD".dataUsingEncoding(NSUTF8StringEncoding)!
+    }
 
     // MARK Functions
 

--- a/Source/BKPeripheralConfiguration.swift
+++ b/Source/BKPeripheralConfiguration.swift
@@ -42,4 +42,8 @@ public class BKPeripheralConfiguration: BKConfiguration {
         super.init(dataServiceUUID: dataServiceUUID, dataServiceCharacteristicUUID: dataServiceCharacteristicUUID)
     }
 
+    public init(dataServiceCBUUID: CBUUID, dataServiceCharacteristicUUID: NSUUID, localName: String? = nil) {
+        self.localName = localName
+        super.init(dataServiceCBUUID: dataServiceCBUUID, dataServiceCharacteristicUUID: dataServiceCharacteristicUUID)
+    }
 }


### PR DESCRIPTION
I found it very useful to be able to use CBUUID for service instead of the NSUUID. What do you think?

```
let serviceCBUUID = CBUUID(string: "FFF0")
let characteristicUUID = NSUUID(UUIDString: "F542647B-70A1-45CA-9F2B-313954D797D9")!
let localName = "My Peripheral"
let configuration = BKPeripheralConfiguration(dataServiceCBUUID: serviceCBUUID, dataServiceCharacteristicUUID:  characteristicUUID, localName: localName)
try peripheral.startWithConfiguration(configuration)
```