### PR TITLE
Add CBUUID to Configuration

### DIFF
--- a/Source/BKConfiguration.swift
+++ b/Source/BKConfiguration.swift
@@ -57,6 +57,13 @@ public class BKConfiguration {
         endOfDataMark = "EOD".dataUsingEncoding(NSUTF8StringEncoding)!
         dataCancelledMark = "COD".dataUsingEncoding(NSUTF8StringEncoding)!
     }
+    
+    public init(dataServiceCBUUID: CBUUID, dataServiceCharacteristicUUID: NSUUID) {
+        self.dataServiceUUID = dataServiceCBUUID
+        self.dataServiceCharacteristicUUID = CBUUID(NSUUID: dataServiceCharacteristicUUID)
+        endOfDataMark = "EOD".dataUsingEncoding(NSUTF8StringEncoding)!
+        dataCancelledMark = "COD".dataUsingEncoding(NSUTF8StringEncoding)!
+    }
 
     // MARK Functions
 

--- a/Source/BKConfiguration.swift
+++ b/Source/BKConfiguration.swift
@@ -65,6 +65,13 @@ public class BKConfiguration {
         dataCancelledMark = "COD".dataUsingEncoding(NSUTF8StringEncoding)!
     }
 
+    public init(dataServiceCBUUID: CBUUID, dataServiceCharacteristicCBUUID: CBUUID) {
+        self.dataServiceUUID = dataServiceCBUUID
+        self.dataServiceCharacteristicUUID = dataServiceCharacteristicCBUUID
+        endOfDataMark = "EOD".dataUsingEncoding(NSUTF8StringEncoding)!
+        dataCancelledMark = "COD".dataUsingEncoding(NSUTF8StringEncoding)!
+    }
+
     // MARK Functions
 
     internal func characteristicUUIDsForServiceUUID(serviceUUID: CBUUID) -> [CBUUID] {

--- a/Source/BKPeripheralConfiguration.swift
+++ b/Source/BKPeripheralConfiguration.swift
@@ -42,4 +42,8 @@ public class BKPeripheralConfiguration: BKConfiguration {
         super.init(dataServiceUUID: dataServiceUUID, dataServiceCharacteristicUUID: dataServiceCharacteristicUUID)
     }
 
+    public init(dataServiceCBUUID: CBUUID, dataServiceCharacteristicUUID: NSUUID, localName: String? = nil) {
+        self.localName = localName
+        super.init(dataServiceCBUUID: dataServiceCBUUID, dataServiceCharacteristicUUID: dataServiceCharacteristicUUID)
+    }
 }

--- a/Source/BKPeripheralConfiguration.swift
+++ b/Source/BKPeripheralConfiguration.swift
@@ -46,4 +46,9 @@ public class BKPeripheralConfiguration: BKConfiguration {
         self.localName = localName
         super.init(dataServiceCBUUID: dataServiceCBUUID, dataServiceCharacteristicUUID: dataServiceCharacteristicUUID)
     }
+    
+    public init(dataServiceCBUUID: CBUUID, dataServiceCharacteristicCBUUID: CBUUID, localName: String? = nil) {
+        self.localName = localName
+        super.init(dataServiceCBUUID: dataServiceCBUUID, dataServiceCharacteristicCBUUID: dataServiceCharacteristicCBUUID)
+    }
 }


### PR DESCRIPTION
While working with some Elecfreak's BLEduino I couldn't find a way to figure out how to use it with NSUUID but using the CBUUID directly worked pretty well

```
let serviceCBUUID = CBUUID(string: "FFF0")
let characteristicCBUUID = CBUUID(string: "fff1")
let configuration = BKConfiguration(dataServiceCBUUID: serviceCBUUID, dataServiceCharacteristicCBUUID: characteristicCBUUID)
try central.startWithConfiguration(configuration)
```

Might be useful to others, if anyone has a proper example while using NSUUID, I'd love to see it. Thanks for the easy to use library! 