### PR TITLE
fixed build on xcode 8.0 with swift 3.0

### DIFF
--- a/Source/BKAvailability.swift
+++ b/Source/BKAvailability.swift
@@ -82,16 +82,16 @@ public enum BKUnavailabilityCause: NilLiteralConvertible {
     case poweredOff
 
     public init(nilLiteral: Void) {
-        self = any
+        self = .any
     }
 
     @available(iOS 10.0, *)
     internal init(centralManagerState: CBManagerState) {
         switch centralManagerState {
-            case .poweredOff: self = poweredOff
-            case .resetting: self = resetting
-            case .unauthorized: self = unauthorized
-            case .unsupported: self = unsupported
+            case .poweredOff: self = .poweredOff
+            case .resetting: self = .resetting
+            case .unauthorized: self = .unauthorized
+            case .unsupported: self = .unsupported
             default: self = nil
         }
     }
@@ -99,10 +99,10 @@ public enum BKUnavailabilityCause: NilLiteralConvertible {
     @available(iOS 10.0, *)
     internal init(peripheralManagerState: CBManagerState) {
         switch peripheralManagerState {
-            case .poweredOff: self = poweredOff
-            case .resetting: self = resetting
-            case .unauthorized: self = unauthorized
-            case .unsupported: self = unsupported
+            case .poweredOff: self = .poweredOff
+            case .resetting: self = .resetting
+            case .unauthorized: self = .unauthorized
+            case .unsupported: self = .unsupported
             default: self = nil
         }
     }
@@ -135,7 +135,7 @@ public extension BKAvailabilityObservable {
         - parameter availabilityObserver: The availability observer to add.
     */
     func addAvailabilityObserver(_ availabilityObserver: BKAvailabilityObserver) {
-        if !availabilityObservers.contains({ $0.availabilityObserver === availabilityObserver }) {
+        if !availabilityObservers.contains(where: { $0.availabilityObserver === availabilityObserver }) {
             availabilityObservers.append(BKWeakAvailabilityObserver(availabilityObserver: availabilityObserver))
         }
     }
@@ -145,7 +145,7 @@ public extension BKAvailabilityObservable {
         - parameter availabilityObserver: The availability observer to remove.
     */
     func removeAvailabilityObserver(_ availabilityObserver: BKAvailabilityObserver) {
-        if availabilityObservers.contains({ $0.availabilityObserver === availabilityObserver }) {
+        if availabilityObservers.contains(where: { $0.availabilityObserver === availabilityObserver }) {
             availabilityObservers.remove(at: availabilityObservers.index(where: { $0 === availabilityObserver })!)
         }
     }

--- a/Source/BKCBPeripheralDelegateProxy.swift
+++ b/Source/BKCBPeripheralDelegateProxy.swift
@@ -94,10 +94,12 @@ internal class BKCBPeripheralDelegateProxy: NSObject, CBPeripheralDelegate {
         // print("peripheral: \(peripheral) didDiscoverDescriptorsForCharacteristic: \(characteristic), error: \(error)")
     }
 
+    @nonobjc
     internal func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor descriptor: CBDescriptor, error: NSError?) {
         // print("peripheral: \(peripheral) didUpdateValueForDescriptor: \(descriptor), error: \(error)")
     }
 
+    @nonobjc
     internal func peripheral(_ peripheral: CBPeripheral, didWriteValueFor descriptor: CBDescriptor, error: NSError?) {
         // print("peripheral: \(peripheral) didWriteValueForDescriptor: \(descriptor), error: \(error)")
     }

--- a/Source/BKCentral.swift
+++ b/Source/BKCentral.swift
@@ -47,12 +47,12 @@ public class BKCentral: BKPeer, BKCBCentralManagerStateDelegate, BKConnectionPoo
 
     // MARK: Type Aliases
 
-    public typealias ScanProgressHandler = ((newDiscoveries: [BKDiscovery]) -> Void)
-    public typealias ScanCompletionHandler = ((result: [BKDiscovery]?, error: BKError?) -> Void)
-    public typealias ContinuousScanChangeHandler = ((changes: [BKDiscoveriesChange], discoveries: [BKDiscovery]) -> Void)
-    public typealias ContinuousScanStateHandler = ((newState: ContinuousScanState) -> Void)
-    public typealias ContinuousScanErrorHandler = ((error: BKError) -> Void)
-    public typealias ConnectCompletionHandler = ((remotePeripheral: BKRemotePeripheral, error: BKError?) -> Void)
+    public typealias ScanProgressHandler = ((_ newDiscoveries: [BKDiscovery]) -> Void)
+    public typealias ScanCompletionHandler = ((_ result: [BKDiscovery]?, _ error: BKError?) -> Void)
+    public typealias ContinuousScanChangeHandler = ((_ changes: [BKDiscoveriesChange], _ discoveries: [BKDiscovery]) -> Void)
+    public typealias ContinuousScanStateHandler = ((_ newState: ContinuousScanState) -> Void)
+    public typealias ContinuousScanErrorHandler = ((_ error: BKError) -> Void)
+    public typealias ConnectCompletionHandler = ((_ remotePeripheral: BKRemotePeripheral, _ error: BKError?) -> Void)
 
     // MARK: Enums
 
@@ -167,10 +167,10 @@ public class BKCentral: BKPeer, BKCBCentralManagerStateDelegate, BKConnectionPoo
                 } else {
                     returnError = .internalError(underlyingError: error)
                 }
-                completionHandler?(result: result, error: returnError)
+                completionHandler?(result, returnError)
             }
         } catch let error {
-            completionHandler?(result: nil, error: .internalError(underlyingError: error))
+            completionHandler?(nil, .internalError(underlyingError: error))
             return
         }
     }
@@ -184,19 +184,19 @@ public class BKCentral: BKPeer, BKCBCentralManagerStateDelegate, BKConnectionPoo
         - parameter errorHandler: An error handler allowing you to react when an error occurs. For now this is also called when the scan is manually interrupted.
     */
     @available(iOS 10.0, *)
-    public func scanContinuouslyWithChangeHandler(_ changeHandler: ContinuousScanChangeHandler, stateHandler: ContinuousScanStateHandler?, duration: TimeInterval = 3, inBetweenDelay: TimeInterval = 3, errorHandler: ContinuousScanErrorHandler?) {
+    public func scanContinuouslyWithChangeHandler(_ changeHandler: @escaping ContinuousScanChangeHandler, stateHandler: ContinuousScanStateHandler?, duration: TimeInterval = 3, inBetweenDelay: TimeInterval = 3, errorHandler: ContinuousScanErrorHandler?) {
         do {
             try stateMachine.handleEvent(.scan)
             continuousScanner.scanContinuouslyWithChangeHandler(changeHandler, stateHandler: { newState in
                 if newState == .stopped && self.availability == .available {
                     _ = try? self.stateMachine.handleEvent(.setAvailable)
                 }
-                stateHandler?(newState: newState)
+                stateHandler?(newState)
             }, duration: duration, inBetweenDelay: inBetweenDelay, errorHandler: { error in
-                errorHandler?(error: .internalError(underlyingError: error))
+                errorHandler?(.internalError(underlyingError: error))
             })
         } catch let error {
-            errorHandler?(error: .internalError(underlyingError: error))
+            errorHandler?(.internalError(underlyingError: error))
         }
     }
 
@@ -214,7 +214,7 @@ public class BKCentral: BKPeer, BKCBCentralManagerStateDelegate, BKConnectionPoo
         - parameter remotePeripheral: The remote peripheral to connect to.
         - parameter completionHandler: A completion handler allowing you to react when the connection attempt succeeded or failed.
     */
-    public func connect(_ timeout: TimeInterval = 3, remotePeripheral: BKRemotePeripheral, completionHandler: ConnectCompletionHandler) {
+    public func connect(_ timeout: TimeInterval = 3, remotePeripheral: BKRemotePeripheral, completionHandler: @escaping ConnectCompletionHandler) {
         do {
             try stateMachine.handleEvent(.connect)
             try connectionPool.connectWithTimeout(timeout, remotePeripheral: remotePeripheral) { remotePeripheral, error in
@@ -222,12 +222,12 @@ public class BKCentral: BKPeer, BKCBCentralManagerStateDelegate, BKConnectionPoo
                 if error == nil {
                     _ = try? self.stateMachine.handleEvent(.setAvailable)
                 } else {
-                    returnError = .internalError(underlyingError: error)
+                    returnError = .internalError(underlyingError: error as! Error?)
                 }
-                completionHandler(remotePeripheral: remotePeripheral, error: returnError)
+                completionHandler(remotePeripheral, returnError)
             }
         } catch let error {
-            completionHandler(remotePeripheral: remotePeripheral, error: .internalError(underlyingError: error))
+            completionHandler(remotePeripheral, .internalError(underlyingError: error))
             return
         }
     }
@@ -278,7 +278,9 @@ public class BKCentral: BKPeer, BKCBCentralManagerStateDelegate, BKConnectionPoo
     }
 
     internal override func sendData(_ data: Data, toRemotePeer remotePeer: BKRemotePeer) -> Bool {
-        guard let remotePeripheral = remotePeer as? BKRemotePeripheral, peripheral = remotePeripheral.peripheral, characteristic = remotePeripheral.characteristicData else {
+        guard let remotePeripheral = remotePeer as? BKRemotePeripheral,
+                let peripheral = remotePeripheral.peripheral,
+                let characteristic = remotePeripheral.characteristicData else {
             return false
         }
         peripheral.writeValue(data, for: characteristic, type: .withoutResponse)

--- a/Source/BKCentralStateMachine.swift
+++ b/Source/BKCentralStateMachine.swift
@@ -28,7 +28,7 @@ internal class BKCentralStateMachine {
 
     // MARK: Enums
 
-    internal enum Error: ErrorProtocol {
+    internal enum BKError: Error {
         case transitioning(currentState: State, validStates: [State])
     }
 
@@ -74,14 +74,14 @@ internal class BKCentralStateMachine {
         case .initialized:
             state = .starting
         default:
-            throw Error.transitioning(currentState: state, validStates: [ .initialized ])
+            throw BKError.transitioning(currentState: state, validStates: [ .initialized ])
         }
     }
 
     private func handleSetAvailableEvent(_ event: Event) throws {
         switch state {
         case .initialized:
-            throw Error.transitioning(currentState: state, validStates: [ .starting, .available, .unavailable(cause: nil) ])
+            throw BKError.transitioning(currentState: state, validStates: [ .starting, .available, .unavailable(cause: nil) ])
         default:
             state = .available
         }
@@ -90,7 +90,7 @@ internal class BKCentralStateMachine {
     private func handleSetUnavailableEvent(_ event: Event, cause: BKUnavailabilityCause) throws {
         switch state {
         case .initialized:
-            throw Error.transitioning(currentState: state, validStates: [ .starting, .available, .unavailable(cause: nil) ])
+            throw BKError.transitioning(currentState: state, validStates: [ .starting, .available, .unavailable(cause: nil) ])
         default:
             state = .unavailable(cause: cause)
         }
@@ -101,7 +101,7 @@ internal class BKCentralStateMachine {
         case .available:
             state = .scanning
         default:
-            throw Error.transitioning(currentState: state, validStates: [ .available ])
+            throw BKError.transitioning(currentState: state, validStates: [ .available ])
         }
     }
 
@@ -110,14 +110,14 @@ internal class BKCentralStateMachine {
         case .available, .scanning:
             break
         default:
-            throw Error.transitioning(currentState: state, validStates: [ .available, .scanning ])
+            throw BKError.transitioning(currentState: state, validStates: [ .available, .scanning ])
         }
     }
 
     private func handleStopEvent(_ event: Event) throws {
         switch state {
         case .initialized:
-            throw Error.transitioning(currentState: state, validStates: [ .starting, .unavailable(cause: nil), .available, .scanning ])
+            throw BKError.transitioning(currentState: state, validStates: [ .starting, .unavailable(cause: nil), .available, .scanning ])
         default:
             state = .initialized
         }

--- a/Source/BKConnectionAttempt.swift
+++ b/Source/BKConnectionAttempt.swift
@@ -34,11 +34,11 @@ internal class BKConnectionAttempt: Equatable {
 
     internal let timer: Timer
     internal let remotePeripheral: BKRemotePeripheral
-    internal let completionHandler: ((peripheralEntity: BKRemotePeripheral, error: BKConnectionPool.Error?) -> Void)
+    internal let completionHandler: ((_ peripheralEntity: BKRemotePeripheral, _ error: BKConnectionPool.BKError?) -> Void)
 
     // MARK: Initialization
 
-    internal init(remotePeripheral: BKRemotePeripheral, timer: Timer, completionHandler: ((peripheralEntity: BKRemotePeripheral, error: BKConnectionPool.Error?) -> Void)) {
+    internal init(remotePeripheral: BKRemotePeripheral, timer: Timer, completionHandler: @escaping ((BKRemotePeripheral, BKConnectionPool.BKError?) -> Void)) {
         self.remotePeripheral = remotePeripheral
         self.timer = timer
         self.completionHandler = completionHandler

--- a/Source/BKConnectionPool.swift
+++ b/Source/BKConnectionPool.swift
@@ -33,7 +33,7 @@ internal class BKConnectionPool: BKCBCentralManagerConnectionDelegate {
 
     // MARK: Enums
 
-    internal enum Error: ErrorProtocol {
+    internal enum BKError: Error {
         case noCentralManagerSet
         case alreadyConnected
         case alreadyConnecting
@@ -42,7 +42,7 @@ internal class BKConnectionPool: BKCBCentralManagerConnectionDelegate {
         case noConnectionAttemptForRemotePeripheral
         case noConnectionForRemotePeripheral
         case timeoutElapsed
-        case `internal`(underlyingError: ErrorProtocol?)
+        case `internal`(underlyingError: Error?)
     }
 
     // MARK: Properties
@@ -54,18 +54,18 @@ internal class BKConnectionPool: BKCBCentralManagerConnectionDelegate {
 
     // MARK: Internal Functions
 
-    internal func connectWithTimeout(_ timeout: TimeInterval, remotePeripheral: BKRemotePeripheral, completionHandler: ((peripheralEntity: BKRemotePeripheral, error: Error?) -> Void)) throws {
+    internal func connectWithTimeout(_ timeout: TimeInterval, remotePeripheral: BKRemotePeripheral, completionHandler: @escaping ((_ peripheralEntity: BKRemotePeripheral, _ error: Error?) -> Void)) throws {
         guard centralManager != nil else {
-            throw Error.noCentralManagerSet
+            throw BKError.noCentralManagerSet
         }
         guard !connectedRemotePeripherals.contains(remotePeripheral) else {
-            throw Error.alreadyConnected
+            throw BKError.alreadyConnected
         }
         guard !connectionAttempts.map({ connectionAttempt in return connectionAttempt.remotePeripheral }).contains(remotePeripheral) else {
-            throw Error.alreadyConnecting
+            throw BKError.alreadyConnecting
         }
         guard remotePeripheral.peripheral != nil else {
-            throw Error.connectionByUUIDIsNotImplementedYet
+            throw BKError.connectionByUUIDIsNotImplementedYet
         }
         let timer = Timer.scheduledTimer(timeInterval: timeout, target: self, selector: #selector(BKConnectionPool.timerElapsed(_:)), userInfo: nil, repeats: false)
         remotePeripheral.prepareForConnection()
@@ -76,7 +76,7 @@ internal class BKConnectionPool: BKCBCentralManagerConnectionDelegate {
     internal func interruptConnectionAttemptForRemotePeripheral(_ remotePeripheral: BKRemotePeripheral) throws {
         let connectionAttempt = connectionAttemptForRemotePeripheral(remotePeripheral)
         guard connectionAttempt != nil else {
-            throw Error.noConnectionAttemptForRemotePeripheral
+            throw BKError.noConnectionAttemptForRemotePeripheral
         }
         failConnectionAttempt(connectionAttempt!, error: .interrupted)
     }
@@ -84,7 +84,7 @@ internal class BKConnectionPool: BKCBCentralManagerConnectionDelegate {
     internal func disconnectRemotePeripheral(_ remotePeripheral: BKRemotePeripheral) throws {
         let connectedRemotePeripheral = connectedRemotePeripherals.filter({ $0 == remotePeripheral }).last
         guard connectedRemotePeripheral != nil else {
-            throw Error.noConnectionForRemotePeripheral
+            throw BKError.noConnectionForRemotePeripheral
         }
         connectedRemotePeripheral?.unsubscribe()
         centralManager.cancelPeripheralConnection(connectedRemotePeripheral!.peripheral!)
@@ -119,13 +119,13 @@ internal class BKConnectionPool: BKCBCentralManagerConnectionDelegate {
         failConnectionAttempt(connectionAttemptForTimer(timer)!, error: .timeoutElapsed)
     }
 
-    private func failConnectionAttempt(_ connectionAttempt: BKConnectionAttempt, error: Error) {
+    private func failConnectionAttempt(_ connectionAttempt: BKConnectionAttempt, error: BKError) {
         connectionAttempts.remove(at: connectionAttempts.index(of: connectionAttempt)!)
         connectionAttempt.timer.invalidate()
         if let peripheral = connectionAttempt.remotePeripheral.peripheral {
             centralManager.cancelPeripheralConnection(peripheral)
         }
-        connectionAttempt.completionHandler(peripheralEntity: connectionAttempt.remotePeripheral, error: error)
+        connectionAttempt.completionHandler(connectionAttempt.remotePeripheral, error)
     }
 
     private func succeedConnectionAttempt(_ connectionAttempt: BKConnectionAttempt) {
@@ -133,7 +133,7 @@ internal class BKConnectionPool: BKCBCentralManagerConnectionDelegate {
         connectionAttempts.remove(at: connectionAttempts.index(of: connectionAttempt)!)
         connectedRemotePeripherals.append(connectionAttempt.remotePeripheral)
         connectionAttempt.remotePeripheral.discoverServices()
-        connectionAttempt.completionHandler(peripheralEntity: connectionAttempt.remotePeripheral, error: nil)
+        connectionAttempt.completionHandler(connectionAttempt.remotePeripheral, nil)
     }
 
     // MARK: CentralManagerConnectionDelegate

--- a/Source/BKErrorDomain.swift
+++ b/Source/BKErrorDomain.swift
@@ -31,9 +31,9 @@ import Foundation
     - RemotePeerNotConnected: The action failed because the remote peer attempted to interact with, was not connected.
     - InternalError(underlyingError): Will be returned if any of the internal or private classes returns an unhandled error.
  */
-public enum BKError: ErrorProtocol {
+public enum BKError: Error {
     case interruptedByUnavailability(cause: BKUnavailabilityCause)
     case failedToConnectDueToTimeout
     case remotePeerNotConnected
-    case internalError(underlyingError: ErrorProtocol?)
+    case internalError(underlyingError: Error?)
 }

--- a/Source/BKPeer.swift
+++ b/Source/BKPeer.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-public typealias BKSendDataCompletionHandler = ((data: Data, remotePeer: BKRemotePeer, error: BKError?) -> Void)
+public typealias BKSendDataCompletionHandler = ((_ data: Data, _ remotePeer: BKRemotePeer, _ error: BKError?) -> Void)
 
 public class BKPeer {
 
@@ -54,7 +54,7 @@ public class BKPeer {
      */
     public func sendData(_ data: Data, toRemotePeer remotePeer: BKRemotePeer, completionHandler: BKSendDataCompletionHandler?) {
         guard connectedRemotePeers.contains(remotePeer) else {
-            completionHandler?(data: data, remotePeer: remotePeer, error: BKError.remotePeerNotConnected)
+            completionHandler?(data,remotePeer,BKError.remotePeerNotConnected)
             return
         }
         let sendDataTask = BKSendDataTask(data: data, destination: remotePeer, completionHandler: completionHandler)
@@ -73,7 +73,7 @@ public class BKPeer {
             let sentEndOfDataMark = sendData(configuration!.endOfDataMark as Data, toRemotePeer: nextTask.destination)
             if sentEndOfDataMark {
                 sendDataTasks.remove(at: sendDataTasks.index(of: nextTask)!)
-                nextTask.completionHandler?(data: nextTask.data as Data, remotePeer: nextTask.destination, error: nil)
+                nextTask.completionHandler?(nextTask.data as Data, nextTask.destination, nil)
                 processSendDataTasks()
             } else {
                 return
@@ -96,7 +96,7 @@ public class BKPeer {
     internal func failSendDataTasksForRemotePeer(_ remotePeer: BKRemotePeer) {
         for sendDataTask in sendDataTasks.filter({ $0.destination == remotePeer }) {
             sendDataTasks.remove(at: sendDataTasks.index(of: sendDataTask)!)
-            sendDataTask.completionHandler?(data: sendDataTask.data as Data, remotePeer: sendDataTask.destination, error: .remotePeerNotConnected)
+            sendDataTask.completionHandler?(sendDataTask.data as Data, sendDataTask.destination, .remotePeerNotConnected)
         }
     }
 

--- a/Source/BKPeripheral.swift
+++ b/Source/BKPeripheral.swift
@@ -211,7 +211,7 @@ public class BKPeripheral: BKPeer, BKCBPeripheralManagerDelegate, BKAvailability
 
     internal func peripheralManager(_ peripheral: CBPeripheralManager, didAddService service: CBService, error: NSError?) {
         if !peripheralManager.isAdvertising {
-            var advertisementData: [String: AnyObject] = [ CBAdvertisementDataServiceUUIDsKey: _configuration.serviceUUIDs ]
+            var advertisementData: [String: Any] = [ CBAdvertisementDataServiceUUIDsKey: _configuration.serviceUUIDs ]
             if let localName = _configuration.localName {
                 advertisementData[CBAdvertisementDataLocalNameKey] = localName
             }
@@ -237,7 +237,9 @@ public class BKPeripheral: BKPeer, BKCBPeripheralManagerDelegate, BKAvailability
             guard writeRequest.characteristic.uuid == characteristicData.uuid else {
                 continue
             }
-            guard let remotePeer = (connectedRemotePeers.filter { $0.identifier == writeRequest.central.identifier } .last), remoteCentral = remotePeer as? BKRemoteCentral, data = writeRequest.value else {
+            guard let remotePeer = (connectedRemotePeers.filter { $0.identifier == writeRequest.central.identifier } .last),
+                  let remoteCentral = remotePeer as? BKRemoteCentral,
+                  let data = writeRequest.value else {
                 continue
             }
             remoteCentral.handleReceivedData(data)

--- a/Source/BKPeripheralStateMachine.swift
+++ b/Source/BKPeripheralStateMachine.swift
@@ -28,7 +28,7 @@ internal class BKPeripheralStateMachine {
 
     // MARK: Enums
 
-    internal enum Error: ErrorProtocol {
+    internal enum BKError: Error {
         case transitioning(currentState: State, validStates: [State])
     }
 
@@ -70,14 +70,14 @@ internal class BKPeripheralStateMachine {
         case .initialized:
             state = .starting
         default:
-            throw Error.transitioning(currentState: state, validStates: [ .initialized ])
+            throw BKError.transitioning(currentState: state, validStates: [ .initialized ])
         }
     }
 
     private func handleSetAvailableEvent(event: Event) throws {
         switch state {
         case .initialized:
-            throw Error.transitioning(currentState: state, validStates: [ .starting, .available, .unavailable(cause: nil) ])
+            throw BKError.transitioning(currentState: state, validStates: [ .starting, .available, .unavailable(cause: nil) ])
         default:
             state = .available
         }
@@ -86,7 +86,7 @@ internal class BKPeripheralStateMachine {
     private func handleSetUnavailableEvent(event: Event, withCause cause: BKUnavailabilityCause) throws {
         switch state {
         case .initialized:
-            throw Error.transitioning(currentState: state, validStates: [ .starting, .available, .unavailable(cause: nil) ])
+            throw BKError.transitioning(currentState: state, validStates: [ .starting, .available, .unavailable(cause: nil) ])
         default:
             state = .unavailable(cause: cause)
         }
@@ -95,7 +95,7 @@ internal class BKPeripheralStateMachine {
     private func handleStopEvent(event: Event) throws {
         switch state {
         case .initialized:
-            throw Error.transitioning(currentState: state, validStates: [ .starting, .available, .unavailable(cause: nil) ])
+            throw BKError.transitioning(currentState: state, validStates: [ .starting, .available, .unavailable(cause: nil) ])
         default:
             state = .initialized
         }

--- a/Source/BKScanner.swift
+++ b/Source/BKScanner.swift
@@ -29,11 +29,11 @@ internal class BKScanner: BKCBCentralManagerDiscoveryDelegate {
 
     // MARK: Type Aliases
 
-    internal typealias ScanCompletionHandler = ((result: [BKDiscovery]?, error: Error?) -> Void)
+    internal typealias ScanCompletionHandler = ((_ result: [BKDiscovery]?, _ error: BKError?) -> Void)
 
     // MARK: Enums
 
-    internal enum Error: ErrorProtocol {
+    internal enum BKError: Error {
         case noCentralManagerSet
         case busy
         case interrupted
@@ -44,17 +44,17 @@ internal class BKScanner: BKCBCentralManagerDiscoveryDelegate {
     internal var configuration: BKConfiguration!
     internal var centralManager: CBCentralManager!
     private var busy = false
-    private var scanHandlers: ( progressHandler: BKCentral.ScanProgressHandler?, completionHandler: ScanCompletionHandler )?
+    private var scanHandlers: (progressHandler: BKCentral.ScanProgressHandler?, completionHandler: ScanCompletionHandler )?
     private var discoveries = [BKDiscovery]()
     private var durationTimer: Timer?
 
     // MARK: Internal Functions
 
-    internal func scanWithDuration(_ duration: TimeInterval, progressHandler: BKCentral.ScanProgressHandler? = nil, completionHandler: ScanCompletionHandler) throws {
+    internal func scanWithDuration(_ duration: TimeInterval, progressHandler: BKCentral.ScanProgressHandler? = nil, completionHandler: @escaping ScanCompletionHandler) throws {
         do {
             try validateForActivity()
             busy = true
-            scanHandlers = (progressHandler: progressHandler, completionHandler: completionHandler)
+            scanHandlers = ( progressHandler: progressHandler, completionHandler: completionHandler)
             centralManager.scanForPeripherals(withServices: configuration.serviceUUIDs, options: nil)
             durationTimer = Timer.scheduledTimer(timeInterval: duration, target: self, selector: #selector(BKScanner.durationTimerElapsed), userInfo: nil, repeats: false)
         } catch let error {
@@ -73,10 +73,10 @@ internal class BKScanner: BKCBCentralManagerDiscoveryDelegate {
 
     private func validateForActivity() throws {
         guard !busy else {
-            throw Error.busy
+            throw BKError.busy
         }
         guard centralManager != nil else {
-            throw Error.noCentralManagerSet
+            throw BKError.noCentralManagerSet
         }
     }
 
@@ -84,7 +84,7 @@ internal class BKScanner: BKCBCentralManagerDiscoveryDelegate {
         endScan(nil)
     }
 
-    private func endScan(_ error: Error?) {
+    private func endScan(_ error: BKError?) {
         invalidateTimer()
         centralManager.stopScan()
         let completionHandler = scanHandlers?.completionHandler
@@ -92,7 +92,7 @@ internal class BKScanner: BKCBCentralManagerDiscoveryDelegate {
         scanHandlers = nil
         self.discoveries.removeAll()
         busy = false
-        completionHandler?(result: discoveries, error: error)
+        completionHandler?(discoveries, error)
     }
 
     private func invalidateTimer() {
@@ -114,7 +114,7 @@ internal class BKScanner: BKCBCentralManagerDiscoveryDelegate {
         let discovery = BKDiscovery(advertisementData: advertisementData, remotePeripheral: remotePeripheral, RSSI: RSSI)
         if !discoveries.contains(discovery) {
             discoveries.append(discovery)
-            scanHandlers?.progressHandler?(newDiscoveries: [ discovery ])
+            scanHandlers?.progressHandler?([ discovery ])
         }
     }
 


### PR DESCRIPTION
error:
1.Function types cannot have argument label 'xxx'; use '_' instead
for typealias rename xxx to _xxx

2.'ErrorProtocol' has been renamed to 'Error'
rename ErrorProtocol to Error and rename inner Error to BKError

3.Method 'xxx' with Objective-C selector 'xxx' conflicts with previous declaration with the same Objective-C selector
add @nonobjc on this method