### PR TITLE
Allow for name updates to propagate though

### DIFF
--- a/Source/BKContinuousScanner.swift
+++ b/Source/BKContinuousScanner.swift
@@ -88,12 +88,29 @@ internal class BKContinousScanner {
             state = .scanning
             stateHandler?(newState: state)
             try scanner.scanWithDuration(duration, progressHandler: { newDiscoveries in
-                let actualDiscoveries = newDiscoveries.filter({ !self.maintainedDiscoveries.contains($0) })
-                if !actualDiscoveries.isEmpty {
-                    self.maintainedDiscoveries += actualDiscoveries
-                    let changes = actualDiscoveries.map({ BKDiscoveriesChange.insert(discovery: $0) })
-                    self.changeHandler?(changes: changes, discoveries: self.maintainedDiscoveries)
+                var changes: [BKDiscoveriesChange] = []
+                
+                //find discoveries that have been updated and add a change for each
+                for newDiscovery in newDiscoveries {
+                    if let index = self.maintainedDiscoveries.index(where: {$0 == newDiscovery && $0.localName != newDiscovery.localName}) {
+                        let outdatedDiscovery = self.maintainedDiscoveries[index]
+                        self.maintainedDiscoveries[index] = newDiscovery
+                        
+                        //TODO: probably need an update change
+                        changes.append(.remove(discovery: outdatedDiscovery))
+                        changes.append(.insert(discovery: newDiscovery))
+                    }
+                    else if !self.maintainedDiscoveries.contains(newDiscovery) {
+                        
+                        self.maintainedDiscoveries.append(newDiscovery)
+                        changes.append(.insert(discovery: newDiscovery))
+                    }
                 }
+
+                if !changes.isEmpty {
+                    self.changeHandler?(changes, self.maintainedDiscoveries)
+                }
+                
             }, completionHandler: { result, error in
                 guard result != nil && error == nil else {
                     self.endScanning(Error.internalError(underlyingError: error!))

--- a/Source/BKScanner.swift
+++ b/Source/BKScanner.swift
@@ -108,11 +108,18 @@ internal class BKScanner: BKCBCentralManagerDiscoveryDelegate {
         guard busy else {
             return
         }
+        
         let RSSI = Int(RSSI)
         let remotePeripheral = BKRemotePeripheral(identifier: peripheral.identifier, peripheral: peripheral)
         remotePeripheral.configuration = configuration
         let discovery = BKDiscovery(advertisementData: advertisementData, remotePeripheral: remotePeripheral, RSSI: RSSI)
-        if !discoveries.contains(discovery) {
+        
+        //find matching discovery, ignore or update if name changed
+        if let index = discoveries.index(where: {$0 == discovery && $0.localName != discovery.localName}) {
+            discoveries[index] = discovery
+            scanHandlers?.progressHandler?([ discovery ])
+        }
+        else if !discoveries.contains(discovery) {
             discoveries.append(discovery)
             scanHandlers?.progressHandler?(newDiscoveries: [ discovery ])
         }


### PR DESCRIPTION
Allow for name updates to propagate though by updating actual discoveries when new discovery is found with same peripheral but different localName.

When a peripheral updates it's name the name update wouldn't be shown because the continuous scanner doesn't recognise an updated name and apply a change. This can also be a problem i've found on some devices where the localName is not available due to CBAdvertisementDataLocalNameKey not being sent with the advertisementData until later.