### PR TITLE
Allow for name updates to propagate though

### DIFF
--- a/Source/BKScanner.swift
+++ b/Source/BKScanner.swift
@@ -108,11 +108,18 @@ internal class BKScanner: BKCBCentralManagerDiscoveryDelegate {
         guard busy else {
             return
         }
+        
         let RSSI = Int(RSSI)
         let remotePeripheral = BKRemotePeripheral(identifier: peripheral.identifier, peripheral: peripheral)
         remotePeripheral.configuration = configuration
         let discovery = BKDiscovery(advertisementData: advertisementData, remotePeripheral: remotePeripheral, RSSI: RSSI)
-        if !discoveries.contains(discovery) {
+        
+        //find matching discovery, ignore or update if name changed
+        if let index = discoveries.index(where: {$0 == discovery && $0.localName != discovery.localName}) {
+            discoveries[index] = discovery
+            scanHandlers?.progressHandler?([ discovery ])
+        }
+        else if !discoveries.contains(discovery) {
             discoveries.append(discovery)
             scanHandlers?.progressHandler?(newDiscoveries: [ discovery ])
         }


### PR DESCRIPTION
Allow for name updates to propagate though by updating actual discoveries when new discovery is found with same peripheral but different localName.

When a peripheral updates it's name the name update wouldn't be shown because the continuous scanner doesn't recognise an updated name and apply a change. This can also be a problem i've found on some devices where the localName is not available due to CBAdvertisementDataLocalNameKey not being sent with the advertisementData until later.

(This is a copy because I don't really know what I'm doing)