### PR TITLE
Attempts to solve Issue #68 on the fork original repo.

### DIFF
--- a/Source/BKCBPeripheralDelegateProxy.swift
+++ b/Source/BKCBPeripheralDelegateProxy.swift
@@ -30,6 +30,7 @@ internal protocol BKCBPeripheralDelegate: class {
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?)
     func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?)
     func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?)
+    func peripheral(_ peripheral: CBPeripheral, didModifyServices invalidatedServices: [CBService])
 }
 
 internal class BKCBPeripheralDelegateProxy: NSObject, CBPeripheralDelegate {
@@ -91,6 +92,10 @@ internal class BKCBPeripheralDelegateProxy: NSObject, CBPeripheralDelegate {
 
     internal func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
 
+    }
+
+    internal func peripheral(_ peripheral: CBPeripheral, didModifyServices invalidatedServices: [CBService]) {
+      delegate?.peripheral(peripheral, didModifyServices: invalidatedServices)
     }
 
 }

--- a/Source/BKPeer.swift
+++ b/Source/BKPeer.swift
@@ -59,7 +59,7 @@ public class BKPeer {
         }
         let sendDataTask = BKSendDataTask(data: data, destination: remotePeer, completionHandler: completionHandler)
         sendDataTasks.append(sendDataTask)
-        if sendDataTasks.count == 1 {
+        if sendDataTasks.count >= 1 {
             processSendDataTasks()
         }
     }

--- a/Source/BKRemotePeripheral.swift
+++ b/Source/BKRemotePeripheral.swift
@@ -166,6 +166,19 @@ public class BKRemotePeripheral: BKRemotePeer, BKCBPeripheralDelegate {
         }
     }
 
+    internal func peripheral(_ peripheral: CBPeripheral, didModifyServices invalidatedServices: [CBService]) {
+      guard let services = peripheral.services else {
+        return
+      }
+      for service in services {
+        if service.characteristics != nil {
+          self.peripheral(peripheral, didDiscoverCharacteristicsFor: service, error: nil)
+        } else {
+          peripheral.discoverCharacteristics(configuration!.characteristicUUIDsForServiceUUID(service.uuid), for: service)
+        }
+      }
+    }
+
     internal func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
         guard service.uuid == configuration!.dataServiceUUID, let dataCharacteristic = service.characteristics?.filter({ $0.uuid == configuration!.dataServiceCharacteristicUUID }).last else {
             return


### PR DESCRIPTION
For the original issue https://github.com/rhummelmose/BluetoothKit/issues/68

In reading the apple doc about this delegate method, it seems to me that this method can be handled by a similar logic to didDiscoverServices, so that's what this PR implements. 

This does build and in my test application, eliminates the error/warning, though I am not 100% sure how to fire the event in a way I can test this further.

In any case, I am submitting this in case it helps you visualize how this might be handled correctly.

Apple docs for the didModifyServices event is here:
https://developer.apple.com/documentation/corebluetooth/cbperipheraldelegate/1518865-peripheral