### PR TITLE
Fix for Issue 77 - BKPeer, sendData

### DIFF
--- a/Source/BKPeer.swift
+++ b/Source/BKPeer.swift
@@ -59,7 +59,7 @@ public class BKPeer {
         }
         let sendDataTask = BKSendDataTask(data: data, destination: remotePeer, completionHandler: completionHandler)
         sendDataTasks.append(sendDataTask)
-        if sendDataTasks.count == 1 {
+        if sendDataTasks.count >= 1 {
             processSendDataTasks()
         }
     }


### PR DESCRIPTION
Solves an issue where sendDataTasks are stuck because there is more than 1 yet the IF condition that fires them off is checking exactly for 1. This should be a check for >= 1 which is what this commit changes. 

See https://github.com/rhummelmose/BluetoothKit/issues/77