### PR TITLE
Updating Pod version from 0.2.0 to 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 use_frameworks!
 
-pod 'BluetoothKit', '~> 0.2.0'
+pod 'BluetoothKit', '~> 0.4.0'
 ```
 
 Then, run the following command:


### PR DESCRIPTION
As per the [BluetoothKit](https://cocoapods.org/pods/BluetoothKit) latest version to use is ```0.4.0``` we are still showing to use ```0.2.0```. Using ```0.2.0``` lead to lots of build error in latest XCode.
Updating the same.