### PR TITLE
fix swift package path

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,9 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "BluetoothKit",
-            dependencies: []),
+            dependencies: [],
+            path: "Source"
+        ),
         .testTarget(
             name: "BluetoothKitTests",
             dependencies: ["BluetoothKit"]),


### PR DESCRIPTION
Set path for the target so that this library can be used by swift package